### PR TITLE
feat: added argument to force open in external browser instead of webview

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -82,7 +82,7 @@ publishing {
             artifact(sourceJar)
             groupId 'com.swedbankpay.mobilesdk'
             artifactId 'mobilesdk'
-            version '1.0.0-beta09'
+            version '1.0.0-beta10'
         }
     }
 }

--- a/sdk/src/main/java/com/swedbankpay/mobilesdk/PaymentFragment.kt
+++ b/sdk/src/main/java/com/swedbankpay/mobilesdk/PaymentFragment.kt
@@ -78,6 +78,7 @@ open class PaymentFragment : Fragment() {
         private var consumer: Consumer? = null
         private var paymentOrder: PaymentOrder? = null
         private var viewModelKey: String? = null
+        private var useExternalBrowser: Boolean = false
         @DefaultUI
         private var enabledDefaultUI = RETRY_PROMPT
 
@@ -100,6 +101,12 @@ open class PaymentFragment : Fragment() {
          * @param viewModelKey the [androidx.lifecycle.ViewModelProvider] key the PaymentFragment uses to find its [PaymentViewModel] in the containing [activity][androidx.fragment.app.FragmentActivity]
          */
         fun viewModelProviderKey(viewModelKey: String?) = apply { this.viewModelKey = viewModelKey }
+
+        /**
+         * Sets if the payment flow should open an external browser or continue in WebView.
+         * @param external set tu true if the external browser should be used instead of the WebView
+         */
+        fun useBrowser(external: Boolean = false) = apply { this.useExternalBrowser = external }
 
         /**
          * Set the enabled default user interfaces.
@@ -133,6 +140,7 @@ open class PaymentFragment : Fragment() {
         fun build(bundle: Bundle) = bundle.apply {
             putParcelable(ARG_CONSUMER, consumer)
             putParcelable(ARG_PAYMENT_ORDER, paymentOrder)
+            putBoolean(ARG_USE_BROWSER, useExternalBrowser)
             viewModelKey?.let { putString(ARG_VIEW_MODEL_PROVIDER_KEY, it) }
             putInt(ARG_ENABLED_DEFAULT_UI, enabledDefaultUI)
         }
@@ -170,6 +178,7 @@ open class PaymentFragment : Fragment() {
         const val ERROR_MESSAGE = 1 shl 2
 
         const val ARG_CONSUMER = "com.swedbankpay.mobilesdk.ARG_CONSUMER"
+        const val ARG_USE_BROWSER = "com.swedbankpay.mobilesdk.ARG_USE_BROWSER"
         const val ARG_PAYMENT_ORDER = "com.swedbankpay.mobilesdk.ARG_PAYMENT_ORDER"
         const val ARG_VIEW_MODEL_PROVIDER_KEY = "com.swedbankpay.mobilesdk.ARG_VIEW_MODEL_PROVIDER_KEY"
         const val ARG_ENABLED_DEFAULT_UI = "com.swedbankpay.mobilesdk.ARG_DEFAULT_UI"
@@ -325,7 +334,8 @@ open class PaymentFragment : Fragment() {
                 val paymentOrder = checkNotNull(getParcelable<PaymentOrder>(ARG_PAYMENT_ORDER)) {
                     "Fragment $this@PaymentFragment does not have a PaymentFragment.ARG_PAYMENT_ORDER argument."
                 }
-                vm.start(consumer, paymentOrder)
+                val useExternal = getBoolean(ARG_USE_BROWSER)
+                vm.start(consumer, paymentOrder, useExternal)
             }
         }
     }

--- a/sdk/src/main/java/com/swedbankpay/mobilesdk/internal/InternalPaymentViewModel.kt
+++ b/sdk/src/main/java/com/swedbankpay/mobilesdk/internal/InternalPaymentViewModel.kt
@@ -106,6 +106,9 @@ internal class InternalPaymentViewModel(app: Application) : AndroidViewModel(app
     init {
         CallbackActivity.onCallbackUrlInvoked.observeForever(callbackUrlObserver)
     }
+    
+    var useExternalBrowser: Boolean = false
+        private set
 
     override fun onCleared() {
         super.onCleared()
@@ -187,7 +190,8 @@ internal class InternalPaymentViewModel(app: Application) : AndroidViewModel(app
         }
     }
 
-    fun start(consumer: Consumer?, paymentOrder: PaymentOrder) {
+    fun start(consumer: Consumer?, paymentOrder: PaymentOrder, useBrowser: Boolean) {
+        useExternalBrowser = useBrowser
         if (processState.value == null) {
             val state = if (consumer != null) {
                 ProcessState.InitializingConsumerSession(consumer, paymentOrder)

--- a/sdk/src/main/java/com/swedbankpay/mobilesdk/internal/WebViewFragment.kt
+++ b/sdk/src/main/java/com/swedbankpay/mobilesdk/internal/WebViewFragment.kt
@@ -52,6 +52,8 @@ internal class WebViewFragment : Fragment() {
 
     private var restored = false
 
+    private var useBrowser: Boolean = false
+
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         // only save webview state if it is not showing the initial page
@@ -109,6 +111,7 @@ internal class WebViewFragment : Fragment() {
                 domStorageEnabled = true
             }
             val vm = ViewModelProviders.of(requireParentFragment())[InternalPaymentViewModel::class.java]
+            useBrowser = vm.useExternalBrowser
             addJavascriptInterface(vm.javascriptInterface, getString(R.string.swedbankpaysdk_javascript_interface_name))
 
             savedInstanceState?.let {
@@ -321,6 +324,7 @@ internal class WebViewFragment : Fragment() {
         }
 
         private fun shouldStartActivity(uri: Uri, resolveInfo: ResolveInfo): Boolean {
+            if(useBrowser) return true
             return when (uri.scheme) {
                 "http", "https" ->
                     // only open http(s) links in external apps if the intent filter is a "good" match


### PR DESCRIPTION
Passing on the `ARG_USE_BROWSER` flag now forces the redirects to run on an external browser instead of inside a WebView within the app. 