### PR TITLE
Fix possible inconsistencies when PaymentFragment is recreated

### DIFF
--- a/sdk/src/main/res/layout/swedbankpaysdk_payment_fragment.xml
+++ b/sdk/src/main/res/layout/swedbankpaysdk_payment_fragment.xml
@@ -80,49 +80,4 @@
             </LinearLayout>
         </androidx.core.widget.NestedScrollView>
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
-
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:id="@+id/swedbankpaysdk_web_view_overlay_holder"
-        android:visibility="invisible"
-        tools:visibility="visible"
-        android:paddingTop="25dp"
-        android:clipToPadding="false"
-        android:background="#22000000"
-        android:clickable="true"
-        android:focusable="true">
-        <LinearLayout
-            android:id="@+id/swedbankpaysdk_web_view_overlay"
-            android:orientation="vertical"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="#ffffff"
-            app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
-            app:behavior_hideable="true"
-            app:behavior_peekHeight="0dp"
-            >
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:padding="16dp"
-                android:elevation="8dp"
-                android:background="#ffffff"
-                />
-            <androidx.core.widget.NestedScrollView
-                android:background="#ffffff"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                >
-                <LinearLayout
-                    android:id="@+id/swedbankpaysdk_web_view_overlay_web"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal" />
-            </androidx.core.widget.NestedScrollView>
-
-        </LinearLayout>
-
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sdk/src/main/res/layout/swedbankpaysdk_web_view_fragment.xml
+++ b/sdk/src/main/res/layout/swedbankpaysdk_web_view_fragment.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:id="@+id/swedbankpaysdk_web_view_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/swedbankpaysdk_web_view_overlay_holder"
+        android:visibility="invisible"
+        tools:visibility="visible"
+        android:paddingTop="25dp"
+        android:clipToPadding="false"
+        android:background="#22000000"
+        android:clickable="true"
+        android:focusable="true">
+        <LinearLayout
+            android:id="@+id/swedbankpaysdk_web_view_overlay"
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="#ffffff"
+            app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+            app:behavior_peekHeight="0dp"
+            app:behavior_hideable="true"
+            app:behavior_skipCollapsed="true"
+            >
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="16dp"
+                android:elevation="8dp"
+                android:background="#ffffff"
+                />
+            <FrameLayout
+                android:id="@+id/swedbankpaysdk_extra_web_view_container"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                />
+        </LinearLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+</FrameLayout>


### PR DESCRIPTION
while an additional web view is visible (opened from a link in the payment flow)

This PR moves the adding and removing of views and callback related to the extra WebView from WebViewModel to WebViewFragment. In doing that, the extra WebView becomes part of WebViewModel proper, similar to the root WebView, allowing the extra WebView to persist across WebViewFragment (child of PaymentFragment) recreation, e.g. during rotations. This involves a bit of code around the BottomSheetBehavior state, as that is persisted as part of the view state, but we actually want to couple it with the extraWebView LiveData.

This has been tested to work in various scenarios, including "Do not keep activities", i.e. bona fide WebViewFragment destruction and recreation (this, of course, loses the original WebViews, effectively resetting the WebViewFragment to the payment menu), and rotation (where the WebViews are preserved).