### PR TITLE
Define the AndroidX Test component versions as a unit for clarity.

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -80,19 +80,29 @@ dependencies {
     compileOnly 'joda-time:joda-time:2.10.10'
     compileOnly 'org.threeten:threetenbp:1.5.1'
 
-    def androidx_test_version = '1.3.0'
-    testImplementation "androidx.test:core:$androidx_test_version"
-    androidTestImplementation "androidx.test:core:$androidx_test_version"
-    androidTestImplementation "androidx.test:runner:$androidx_test_version"
+    // The AndroidX Test Library has a strange way of versioning its components.
+    // These should only be changed as an atom, reflecting a single release of AndroidX Test.
+    // Ref: https://developer.android.com/jetpack/androidx/releases/test
+    // Note that androidx.fragment:fragment-testing has a strict AndroidX Test dependency,
+    // so we cannot always update these to the newest stable release immediately.
+    def androidx_test_versions = [
+            core: '1.3.0',
+            espresso: '3.3.0',
+            junit: '1.1.2'
+    ]
 
-    def espresso_version = '3.3.0'
-    testImplementation "androidx.test.espresso:espresso-core:$espresso_version"
-    testImplementation "androidx.test.espresso:espresso-intents:$espresso_version"
-    androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_version"
-    androidTestImplementation "androidx.test.espresso:espresso-web:$espresso_version"
+    testImplementation "androidx.test:core:$androidx_test_versions.core"
+    androidTestImplementation "androidx.test:core:$androidx_test_versions.core"
+    androidTestImplementation "androidx.test:runner:$androidx_test_versions.core"
+
+    testImplementation "androidx.test.espresso:espresso-core:$androidx_test_versions.espresso"
+    testImplementation "androidx.test.espresso:espresso-intents:$androidx_test_versions.espresso"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$androidx_test_versions.espresso"
+    androidTestImplementation "androidx.test.espresso:espresso-web:$androidx_test_versions.espresso"
+
+    testImplementation "androidx.test.ext:junit:$androidx_test_versions.junit"
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'androidx.test.ext:junit:1.1.3'
     testImplementation 'org.robolectric:robolectric:4.6.1'
     testImplementation 'org.mockito:mockito-inline:3.10.0'
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'


### PR DESCRIPTION
Also revert unintended change to AndroidX JUnit library.