### PR TITLE
Fix ProGuard configuration

### DIFF
--- a/sdk/proguard-rules.pro
+++ b/sdk/proguard-rules.pro
@@ -17,8 +17,12 @@
     @com.google.gson.annotations.SerializedName <fields>;
 }
 
--keepclassmembers,allowobfuscation class com.swedbankpay.mobilesdk.TerminalFailure {
-    <init>();
+-keepclassmembers,allowobfuscation class com.swedbankpay.mobilesdk.** implements com.google.gson.JsonSerializer {
+    public com.google.gson.JsonElement serialize(java.lang.Object, java.lang.reflect.Type, com.google.gson.JsonSerializationContext);
+}
+
+-keepclassmembers,allowobfuscation class com.swedbankpay.mobilesdk.** implements com.google.gson.JsonDeserializer {
+    public java.lang.Object deserialize(com.google.gson.JsonElement, java.lang.reflect.Type, com.google.gson.JsonDeserializationContext);
 }
 
 -keepclassmembers,allowobfuscation class com.swedbankpay.mobilesdk.internal.remote.json.* {


### PR DESCRIPTION
This fixes types using the `@JsonAdapter` annotation causing crashes when minification is enabled.

The reason was that R8 was too aggressively deciding that the the classes used only in `@JsonAdapter` annotation did not have their methods used. Update the ProGuard rules to explicitly keep the relevant methods.

Also removed an unused rule.