### PR TITLE
Declare dependency versions in a version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,34 +22,6 @@ plugins {
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
 }
 
-// Versions for common dependencies.
-// This should be changed to a version catalog when they become public.
-// Ref: https://docs.gradle.org/current/userguide/platforms.html
-ext.versions = [
-        'kotlinx_coroutines': '1.5.1',
-
-        'androidx_fragment': '1.3.6',
-        'androidx_lifecycle': '2.3.1',
-
-        // The AndroidX Test Library has a strange way of versioning its components.
-        // These should only be changed as an atom, reflecting a single release of AndroidX Test.
-        // Ref: https://developer.android.com/jetpack/androidx/releases/test
-        // Note that androidx.fragment:fragment-testing has a strict AndroidX Test dependency,
-        // so we cannot always update these to the newest stable release immediately.
-        'androidx_test': [
-                core: '1.3.0',
-                espresso: '3.3.0',
-                junit: '1.1.2'
-        ],
-
-        'gson': '2.8.8',
-        'okhttp': '4.9.1',
-        'junit': '4.13.2',
-        'mockito': '3.12.4',
-        'mockito_kotlin': '2.2.0',
-        'robolectric': '4.6.1'
-]
-
 // Support for Github Actions based CI: create named versions from Github releases
 static def readGithubReleaseEvent() {
     def isRelease = System.getenv('GITHUB_EVENT_NAME') == 'release'

--- a/mobilesdk-merchantbackend/build.gradle
+++ b/mobilesdk-merchantbackend/build.gradle
@@ -34,33 +34,30 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$versions.kotlinx_coroutines"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$versions.kotlinx_coroutines"
+    implementation libs.kotlinx.coroutines.core
+    implementation libs.kotlinx.coroutines.android
 
-    debugImplementation "androidx.fragment:fragment-testing:$versions.androidx_fragment"
+    debugImplementation libs.fragment.testing
 
-    implementation 'com.google.android.gms:play-services-base:17.6.0'
-    implementation 'com.google.android.gms:play-services-basement:17.6.0'
+    implementation libs.play.services.base
+    implementation libs.play.services.basement
 
-    implementation "com.google.code.gson:gson:$versions.gson"
+    implementation libs.gson
 
-    implementation "com.squareup.okhttp3:okhttp:$versions.okhttp"
-    testImplementation "com.squareup.okhttp3:mockwebserver:$versions.okhttp"
-    androidTestImplementation "com.squareup.okhttp3:mockwebserver:$versions.okhttp"
+    implementation libs.okhttp
 
-    androidTestImplementation "androidx.test:core:$versions.androidx_test.core"
-    androidTestImplementation "androidx.test:runner:$versions.androidx_test.core"
-
-    testImplementation "androidx.test.ext:junit:$versions.androidx_test.junit"
-
-    testImplementation "junit:junit:$versions.junit"
-    testImplementation "org.robolectric:robolectric:$versions.robolectric"
-    testImplementation "org.mockito:mockito-inline:$versions.mockito"
-    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$versions.mockito_kotlin"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    testImplementation libs.androidx.test.junit
+    testImplementation libs.junit
+    testImplementation libs.robolectric
+    testImplementation libs.mockito.inline
+    testImplementation libs.mockito.kotlin
+    testImplementation libs.mockwebserver
 
-    androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
-    androidTestImplementation "junit:junit:$versions.junit"
+    androidTestImplementation libs.androidx.test.core
+    androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.uiautomator
+    androidTestImplementation libs.junit
 }
 
 task sourceJar(type: Jar) {

--- a/mobilesdk/build.gradle
+++ b/mobilesdk/build.gradle
@@ -38,49 +38,46 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$versions.kotlinx_coroutines"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$versions.kotlinx_coroutines"
+    implementation libs.kotlinx.coroutines.core
+    implementation libs.kotlinx.coroutines.android
 
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'androidx.core:core-ktx:1.6.0'
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.core.ktx
 
-    implementation "androidx.fragment:fragment-ktx:$versions.androidx_fragment"
-    debugImplementation "androidx.fragment:fragment-testing:$versions.androidx_fragment"
+    implementation libs.fragment.ktx
+    debugImplementation libs.fragment.testing
 
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$versions.androidx_lifecycle"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$versions.androidx_lifecycle"
+    implementation libs.lifecycle.livedata.ktx
+    implementation libs.lifecycle.viewmodel.ktx
 
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
-    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
-    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation libs.constraintlayout
+    implementation libs.swiperefreshlayout
+    implementation libs.coordinatorlayout
+    implementation libs.material
 
-    implementation "com.squareup.okhttp3:okhttp:$versions.okhttp"
+    implementation libs.okhttp
 
-    implementation "com.google.code.gson:gson:$versions.gson"
+    implementation libs.gson
 
-    compileOnly 'joda-time:joda-time:2.10.10'
-    compileOnly 'org.threeten:threetenbp:1.5.1'
+    compileOnly libs.joda.time
+    compileOnly libs.threetenbp
 
-    testImplementation "androidx.test:core:$versions.androidx_test.core"
-    androidTestImplementation "androidx.test:core:$versions.androidx_test.core"
-    androidTestImplementation "androidx.test:runner:$versions.androidx_test.core"
+    testImplementation libs.androidx.test.core
+    testImplementation libs.espresso.core
+    testImplementation libs.espresso.intents
+    testImplementation libs.androidx.test.junit
+    testImplementation libs.junit
+    testImplementation libs.robolectric
+    testImplementation libs.mockito.inline
+    testImplementation libs.mockito.kotlin
 
-    testImplementation "androidx.test.espresso:espresso-core:$versions.androidx_test.espresso"
-    testImplementation "androidx.test.espresso:espresso-intents:$versions.androidx_test.espresso"
-    androidTestImplementation "androidx.test.espresso:espresso-core:$versions.androidx_test.espresso"
-    androidTestImplementation "androidx.test.espresso:espresso-web:$versions.androidx_test.espresso"
-
-    testImplementation "androidx.test.ext:junit:$versions.androidx_test.junit"
-
-    testImplementation "junit:junit:$versions.junit"
-    testImplementation "org.robolectric:robolectric:$versions.robolectric"
-    testImplementation "org.mockito:mockito-inline:$versions.mockito"
-    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$versions.mockito_kotlin"
-
-    androidTestImplementation "junit:junit:$versions.junit"
-    androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito-inline:2.28.1'
-    androidTestImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$versions.mockito_kotlin"
+    androidTestImplementation libs.androidx.test.core
+    androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.espresso.core
+    androidTestImplementation libs.espresso.web
+    androidTestImplementation libs.junit
+    androidTestImplementation libs.dexmaker.mockito.inline
+    androidTestImplementation libs.mockito.kotlin
 }
 
 task sourceJar(type: Jar) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,51 @@
 include ':mobilesdk'
 include ':mobilesdk-merchantbackend'
 include ':testcommon'
+
+enableFeaturePreview('VERSION_CATALOGS')
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            alias 'kotlinx-coroutines-core' to 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1'
+            alias 'kotlinx-coroutines-android' to 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1'
+
+            alias 'androidx-appcompat' to 'androidx.appcompat:appcompat:1.3.1'
+            alias 'androidx-core-ktx' to 'androidx.core:core-ktx:1.6.0'
+            alias 'fragment-ktx' to 'androidx.fragment:fragment-ktx:1.3.6'
+            alias 'fragment-testing' to 'androidx.fragment:fragment-testing:1.3.6'
+            alias 'lifecycle-livedata-ktx' to 'androidx.lifecycle:lifecycle-livedata-ktx:2.3.1'
+            alias 'lifecycle-viewmodel-ktx' to 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1'
+            alias 'constraintlayout' to 'androidx.constraintlayout:constraintlayout:2.1.0'
+            alias 'coordinatorlayout' to 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
+            alias 'swiperefreshlayout' to 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
+
+            alias 'androidx-test-core' to 'androidx.test:core:1.3.0'
+            alias 'androidx-test-runner' to 'androidx.test:runner:1.3.0'
+
+            alias 'espresso-core' to 'androidx.test.espresso:espresso-core:3.3.0'
+            alias 'espresso-intents' to 'androidx.test.espresso:espresso-intents:3.3.0'
+            alias 'espresso-web' to 'androidx.test.espresso:espresso-web:3.3.0'
+
+            alias 'androidx-test-junit' to 'androidx.test.ext:junit:1.1.2'
+            alias 'uiautomator' to 'androidx.test.uiautomator:uiautomator:2.2.0'
+
+            alias 'material' to 'com.google.android.material:material:1.4.0'
+            alias 'play-services-base' to 'com.google.android.gms:play-services-base:17.6.0'
+            alias 'play-services-basement' to 'com.google.android.gms:play-services-basement:17.6.0'
+            alias 'gson' to 'com.google.code.gson:gson:2.8.8'
+
+            alias 'junit' to 'junit:junit:4.13.2'
+
+            alias 'joda-time' to 'joda-time:joda-time:2.10.10'
+            alias 'threetenbp' to 'org.threeten:threetenbp:1.5.1'
+
+            alias 'okhttp' to 'com.squareup.okhttp3:okhttp:4.9.1'
+            alias 'mockwebserver' to 'com.squareup.okhttp3:mockwebserver:4.9.1'
+
+            alias 'robolectric' to 'org.robolectric:robolectric:4.6.1'
+            alias 'mockito-inline' to 'org.mockito:mockito-inline:3.12.4'
+            alias 'mockito-kotlin' to 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
+            alias 'dexmaker-mockito-inline' to 'com.linkedin.dexmaker:dexmaker-mockito-inline:2.28.1'
+        }
+    }
+}

--- a/testcommon/build.gradle
+++ b/testcommon/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$versions.androidx_lifecycle"
-    implementation "junit:junit:$versions.junit"
-    implementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$versions.mockito_kotlin"
+    implementation libs.lifecycle.livedata.ktx
+    implementation libs.junit
+    implementation libs.mockito.kotlin
 }


### PR DESCRIPTION
The way shared dependency versions are currently declared appears to be a little too clever for dependabot. This PR changes version management to use version catalogs (https://docs.gradle.org/current/userguide/platforms.html), an incubating feature of Gradle 7. Hopefully the version catalog format is more readily understood by dependabot.

Using `enableFeaturePreview('VERSION_CATALOGS')` has no bearing on users of the SDK, it only affects how the SDK itself is build. As the feature is still incubating, it is possible, though not really likely, that future Gradle versions will break the build script. Will cross that bridge when we come to it.