### PR TITLE
Fix dependabot for Kotlin DSL build.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    apply(from = "dependencies.gradle.kts")
+    apply(from = "./dependencies.gradle.kts")
 
     repositories {
         google()


### PR DESCRIPTION
Hopefully this fixes it. Dependabot gradle support is weird.