### PR TITLE
Dokka is not playing nice with gradle plugin

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -16,3 +16,5 @@ jobs:
           java-version: '11'
       - name: Run Checks with Gradle
         run: ./gradlew check
+      - name: Check generating docs   
+        run: ./gradlew dokkaGfm  

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,7 @@ buildscript {
 
 plugins {
     kotlin("android") version "1.6.21" apply false
-    id("org.jetbrains.dokka") version "1.6.21" apply false
-
+    id("org.jetbrains.dokka") version "1.6.10" apply false
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
 }
 

--- a/dependencies/dependencies.gradle.kts
+++ b/dependencies/dependencies.gradle.kts
@@ -1,7 +1,7 @@
 // Declare all dependency versions here so that they are consistent between subprojects.
 
 extra["libs"] = mapOf(
-   "android-gradle-plugin" to "com.android.tools.build:gradle:7.1.3",
+   "android-gradle-plugin" to "com.android.tools.build:gradle:7.0.0",
 
    "jgit" to "org.eclipse.jgit:org.eclipse.jgit:6.1.0.202203080745-r",
 

--- a/dependencies/dependencies.gradle.kts
+++ b/dependencies/dependencies.gradle.kts
@@ -1,7 +1,7 @@
 // Declare all dependency versions here so that they are consistent between subprojects.
 
 extra["libs"] = mapOf(
-   "android-gradle-plugin" to "com.android.tools.build:gradle:7.0.0",
+   "android-gradle-plugin" to "com.android.tools.build:gradle:7.1.3",
 
    "jgit" to "org.eclipse.jgit:org.eclipse.jgit:6.1.0.202203080745-r",
 


### PR DESCRIPTION
The gradle-plugin version 7.1.0 and above fails with dokka 1.6.20 (to generate docs, which is needed to publish). A big mess but solved by downgrading dokka to 1.6.10. They have promised a fix in future versions, so no need to spend additional time on this.