### PR TITLE
Creating the JavaScriptEventListener and building it’s test

### DIFF
--- a/mobilesdk/src/main/java/com/swedbankpay/mobilesdk/internal/InternalPaymentViewModel.kt
+++ b/mobilesdk/src/main/java/com/swedbankpay/mobilesdk/internal/InternalPaymentViewModel.kt
@@ -34,7 +34,7 @@ internal class InternalPaymentViewModel(app: Application) : AndroidViewModel(app
 
     private val processState = MutableLiveData<ProcessState?>()
     private val moveToNextStateJob = MutableLiveData<Job?>()
-
+    
     val webViewShowingRootPage = MutableLiveData(false)
 
     var reloadRequested = false
@@ -226,6 +226,9 @@ internal class InternalPaymentViewModel(app: Application) : AndroidViewModel(app
     
     fun onGeneralEvent(message: String) {
         Log.d(LOG_TAG, "onGeneralEvent: $message")
+        publicVm?.run {
+            javaScriptEventListener?.javaScriptEvent(this, message)
+        }
     }
 
     fun getPaymentMenuHtmlContent(): HtmlContent? {


### PR DESCRIPTION
To be more versatile we now allow clients to listen to the payment menu's JavaScript events. E.g. to make sure everything is visible after a OnCheckoutResized-event or to just allow for better loggin/debugging.