### PR TITLE
Fix bug that spammed merchants with 3Dsecure callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Swedbank Pay Android SDK facilitates embedding of [Swedbank Pay payments](ht
 Gradle:
 ```gradle
 dependencies {
-  implementation 'com.swedbankpay.mobilesdk:mobilesdk:5.0.5'
+  implementation 'com.swedbankpay.mobilesdk:mobilesdk:5.0.6'
 }
 ```
 

--- a/mobilesdk/src/main/java/com/swedbankpay/mobilesdk/paymentsession/PaymentSession.kt
+++ b/mobilesdk/src/main/java/com/swedbankpay/mobilesdk/paymentsession/PaymentSession.kt
@@ -990,6 +990,7 @@ class PaymentSession(private var orderInfo: ViewPaymentOrderInfo? = null) {
         _paymentSessionState.setValue(PaymentSessionState.SessionProblemOccurred(problemDetails))
 
         stopObservingCallbacks()
+        stopObservingScaRedirect()
 
         BeaconService.logEvent(
             eventAction = EventAction.SDKCallbackInvoked(


### PR DESCRIPTION
Stop observing scaRedirect when cancel ouf of 3d secure view to not spam merchant with show3Dsecure callbacks.